### PR TITLE
Revert "Bump striptags from 3.1.1 to 3.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10443,9 +10443,9 @@
       }
     },
     "striptags": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
-      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "stylus": {
       "version": "0.54.7",


### PR DESCRIPTION
Reverts Code37/Code37.github.io#10